### PR TITLE
reorganize kminvalues as separate package

### DIFF
--- a/db.go
+++ b/db.go
@@ -83,6 +83,13 @@ func (gr GetRequest) Execute(database *levigo.DB, ro *levigo.ReadOptions, wo *le
 	}
 
 	kmv, err := kminvalues.KMinValuesFromBytes(data)
+	if err != nil {
+		if len(data) == 0 {
+			kmv = kminvalues.NewKMinValues(*defaultSize)
+		} else {
+			return nil, err
+		}
+	}
 	return kmv, err
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -3,9 +3,20 @@ package main
 import (
 	"github.com/bmizerany/assert"
 	"github.com/jmhodges/levigo"
+	"github.com/mynameisfiber/gocountme/kminvalues"
 	"log"
 	"testing"
+	"math/rand"
 )
+
+func GetRandHash() uint64 {
+	hash := uint64(rand.Int63())
+	if rand.Intn(2) == 0 {
+		hash += 1 << 63
+	}
+	return hash
+}
+
 
 func TestDB(t *testing.T) {
 	SetupDB()
@@ -25,7 +36,7 @@ func TestDB(t *testing.T) {
 	clean()
 	defer clean()
 
-	kmv := NewKMinValues(50)
+	kmv := kminvalues.NewKMinValues(50)
 
 	for i := 0; i < 100; i++ {
 		kmv.AddHash(GetRandHash())

--- a/db_test.go
+++ b/db_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/jmhodges/levigo"
 	"github.com/mynameisfiber/gocountme/kminvalues"
 	"log"
-	"testing"
 	"math/rand"
+	"testing"
 )
 
 func GetRandHash() uint64 {
@@ -16,7 +16,6 @@ func GetRandHash() uint64 {
 	}
 	return hash
 }
-
 
 func TestDB(t *testing.T) {
 	SetupDB()

--- a/httpapi.go
+++ b/httpapi.go
@@ -342,7 +342,6 @@ func main() {
 	}
 
 	log.Println("Opening levelDB")
-	Default_KMinValues_Size = *defaultSize
 	opts := levigo.NewOptions()
 	opts.SetCache(levigo.NewLRUCache(*leveldbLRUCache))
 	opts.SetCreateIfMissing(true)

--- a/kminvalues/kminvalues_test.go
+++ b/kminvalues/kminvalues_test.go
@@ -1,4 +1,4 @@
-package main
+package kminvalues
 
 import (
 	"encoding/binary"
@@ -12,9 +12,9 @@ import (
 
 func TestKMinValuesConstruct(t *testing.T) {
 	kmv := NewKMinValues(50)
-	assert.Equal(t, kmv.MaxSize, 50)
-	assert.Equal(t, len(kmv.Raw), 0)
-	assert.Equal(t, cap(kmv.Raw), 50*BytesUint64)
+	assert.Equal(t, kmv.maxSize, 50)
+	assert.Equal(t, len(kmv.raw), 0)
+	assert.Equal(t, cap(kmv.raw), 50*bytesUint64)
 }
 
 func GetRandHash() uint64 {
@@ -38,9 +38,10 @@ func TestKMinValuesBytes(t *testing.T) {
 	}
 
 	bkmv := kmv.Bytes()
-	kmv2 := KMinValuesFromBytes(bkmv)
+	kmv2, err := KMinValuesFromBytes(bkmv)
+	assert.Equal(t, err, nil)
 
-	assert.Equal(t, kmv.MaxSize, kmv2.MaxSize)
+	assert.Equal(t, kmv.maxSize, kmv2.maxSize)
 	for i := 0; i < kmv.Len(); i++ {
 		assert.Equal(t, kmv.GetHash(i), kmv2.GetHash(i))
 	}
@@ -59,7 +60,7 @@ func TestKMinValuesSimple(t *testing.T) {
 	kmv.AddHash(5)
 	kmv.AddHash(6)
 
-	assert.Equal(t, kmv.MaxSize, kmv.Len())
+	assert.Equal(t, kmv.maxSize, kmv.Len())
 
 	for i, k := range []uint64{5, 4, 3, 2, 1} {
 		assert.Equal(t, kmv.GetHash(i), k)

--- a/parsequery.go
+++ b/parsequery.go
@@ -2,11 +2,11 @@ package main
 
 //
 //    in order to request:
-//    
+//
 //        Jaccard( key1 u key2, key8 n key3 )
-//    
+//
 //    we request:
-//    
+//
 //    {
 //        "method" : "jaccard",
 //        "set" : [
@@ -18,18 +18,18 @@ package main
 //                "method" : "intersection",
 //                "keys" : ["key8", "key3"],
 //            },
-//    
+//
 //        ]
 //    }
-//    
+//
 //    ============================================
-//    
+//
 //    in order to request:
-//    
+//
 //        Card( (key1 u key2 u key3) n key5)
-//    
+//
 //    we request:
-//    
+//
 //    {
 //        "method" : "cardinality",
 //        "set" : [
@@ -52,17 +52,19 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/mynameisfiber/gocountme/kminvalues"
 	"strings"
 )
 
 var (
-	KeysAndSetError            = fmt.Errorf("Both keys and set are specified in query")
-	CardinalitySingleTermError = fmt.Errorf("Method 'cardinality' can only take in one data source")
-	GetSingleTermError         = fmt.Errorf("Method 'get' can only take in one data source")
-	SetNeedsKMV                = fmt.Errorf("Set specified with float output")
-	InvalidMethod              = fmt.Errorf("Unrecognized method")
-	MethodSetSize              = fmt.Errorf("Method requires 2+ sets or keys")
+	KeysAndSetError            = errors.New("Both keys and set are specified in query")
+	CardinalitySingleTermError = errors.New("Method 'cardinality' can only take in one data source")
+	GetSingleTermError         = errors.New("Method 'get' can only take in one data source")
+	SetNeedsKMV                = errors.New("Set specified with float output")
+	InvalidMethod              = errors.New("Unrecognized method")
+	MethodSetSize              = errors.New("Method requires 2+ sets or keys")
 )
 
 type Element struct {
@@ -72,10 +74,10 @@ type Element struct {
 }
 
 type QueryResult struct {
-	Key   string         `json:"key"`
-	Kmv   *KMinValues    `json:"set"`
-	Num   float64        `json:"result"`
-	Multi []*QueryResult `json:"multi_result,omitempty"`
+	Key   string                 `json:"key"`
+	Kmv   *kminvalues.KMinValues `json:"set"`
+	Num   float64                `json:"result"`
+	Multi []*QueryResult         `json:"multi_result,omitempty"`
 }
 
 func ParseQuery(query_raw []byte) (*QueryResult, error) {
@@ -93,11 +95,11 @@ func parseQuery(e *Element) (*QueryResult, error) {
 		return nil, KeysAndSetError
 	}
 
-	var data []*KMinValues
+	var data []*kminvalues.KMinValues
 	var keys []string
 
 	if len(e.Keys) != 0 {
-		data = make([]*KMinValues, len(e.Keys))
+		data = make([]*kminvalues.KMinValues, len(e.Keys))
 		resultChan := make(chan Result, len(e.Keys)+1)
 		for _, key := range e.Keys {
 			getRequest := GetRequest{
@@ -120,7 +122,7 @@ func parseQuery(e *Element) (*QueryResult, error) {
 		}
 		keys = e.Keys
 	} else if len(e.Set) != 0 {
-		data = make([]*KMinValues, len(e.Set))
+		data = make([]*kminvalues.KMinValues, len(e.Set))
 		keys = make([]string, len(e.Set))
 		for i := 0; i < len(e.Set); i++ {
 			tmp, err := parseQuery(&e.Set[i])


### PR DESCRIPTION
This moves kminvalues code into a separate directory with a separate package name so other projects can import that directly
